### PR TITLE
fix(places): bare brand names near short utility keywords + i18n in refresh route

### DIFF
--- a/plugins/osm-slot/index.js
+++ b/plugins/osm-slot/index.js
@@ -6,7 +6,13 @@ import {
   createNominatimGeocoder,
   NOMINATIM_DEFAULT_ENDPOINT,
 } from "./nominatim-geocoder.mjs";
+let _i18n = null;
 function t(key, context) {
+  // Resolve from the plugin's own locale so plugin-route responses (e.g. the
+  // "use my location" refresh) render real text instead of raw {{ t:... }}
+  // placeholders. degoog only resolves placeholders for slot output, not for
+  // plugin-route responses. Falls back to the placeholder if not loaded.
+  if (_i18n && typeof _i18n[key] === "string") return _i18n[key];
   return `{{ t:plugin-osm-slot.${key} }}`;
 }
 
@@ -248,6 +254,13 @@ export const slot = {
         .readFile("icons/osm-provider.svg")
         .then((svg) => {
           _osmProviderIconSvg = _normalizeMapExtIconSvg(svg, "0 0 24 24");
+        })
+        .catch(() => {});
+      ctx
+        .readFile("locales/en.json")
+        .then((raw) => {
+          const parsed = JSON.parse(raw);
+          _i18n = parsed["plugin-osm-slot"] || null;
         })
         .catch(() => {});
     }

--- a/plugins/osm-slot/query-guards.js
+++ b/plugins/osm-slot/query-guards.js
@@ -209,7 +209,12 @@ function isLikelyUtilityKeywordTypo(token) {
     if (lower.startsWith(word) && lower.length <= word.length + 2) return true;
 
     // Near miss: weater, forcast, translat
-    if (Math.abs(lower.length - word.length) <= 2 && _levenshtein(lower, word) <= 2) {
+    // Distance-2 only for longer keywords (>=7 chars). For short words like
+    // "color"/"clock"/"timer", distance 2 collides with unrelated real words
+    // (e.g. the brand "coles" is 2 edits from "color"), wrongly suppressing
+    // Places. Genuine short-word typos are ~1 edit.
+    var maxDist = word.length >= 7 ? 2 : 1;
+    if (Math.abs(lower.length - word.length) <= maxDist && _levenshtein(lower, word) <= maxDist) {
       return true;
     }
   }


### PR DESCRIPTION
Two independent bug fixes in the **Places (`osm-slot`)** plugin.

### 1. Bare brand names near short utility keywords never trigger
`isLikelyUtilityKeywordTypo` treats any single-token query within **edit-distance 2** of a `UTILITY_SINGLE_WORDS` entry as a typo and makes Places yield. For short keywords this collides with real words/brands — e.g. **`coles`** (a major AU supermarket) is exactly 2 edits from **`color`**, so `analyzePlaceIntent("coles")` returns `null` and Places never shows, while `aldi`/`bunnings`/`coles supermarket`/`coles near me` all work.

**Fix:** make the near-miss distance length-aware — distance 2 for keywords ≥ 7 chars, distance 1 for shorter ones. Genuine short typos are ~1 edit, so `weater`→weather / `forcast`→forecast still match.

### 2. `{{ t:... }}` placeholders leak in the "use my location" refresh
The refresh route (`routes` → `path: "refresh"`) returns HTML built with `t()`, but degoog only resolves `{{ t:... }}` placeholders for **slot output**, not for **plugin-route responses**. So after tapping "use my location", the re-rendered card shows raw `plugin-osm-slot.places` etc.

**Fix:** load the plugin's own `locales/en.json` in `init()` via `ctx.readFile` and have `t()` resolve from it, falling back to the placeholder when unavailable.

### Verification
- `coles` / `Coles` → Places triggers ✅
- `weater`, `forcast` → still yield to their plugins ✅
- `color`, `weather` → unchanged ✅
- "use my location" refresh → real text, zero unresolved placeholders ✅

Both are minimal and self-contained. Happy to split into two PRs if you'd prefer.
