### PR TITLE
Improve LiterallyApple theme layout and styling

### DIFF
--- a/themes/literallyapple/scripts/search.js
+++ b/themes/literallyapple/scripts/search.js
@@ -2532,67 +2532,9 @@ function wrapResultsStats(meta) {
     }
 })();
 
-/* ── 4b. Results tabs scroll rail (mobile arrows + desktop grid grouping) ── */
+/* ── 4b. Results tabs: wrapping capsule with a separate Filters control ── */
 (() => {
-    const TABS_SCROLL_SELECTOR = ".lg-results-tabs__scroll";
-    const TABS_RAIL_CLASS = "lg-results-tabs-rail";
-    const mobileQuery = window.matchMedia("(max-width: 767px)");
-    const NAV_ICON_PREV =
-        `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6" /></svg>`;
-    const NAV_ICON_NEXT =
-        `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6" /></svg>`;
-
-    function horizontalTabsScrollStep(scrollEl) {
-        return Math.max(120, Math.round(scrollEl.clientWidth * 0.72));
-    }
-
-    function updateTabsNavState() {
-        const tabs = getResultsTabs();
-        const rail = tabs?.querySelector(`.${TABS_RAIL_CLASS}`);
-        const scrollEl = rail?.querySelector(TABS_SCROLL_SELECTOR);
-        const prevBtn = rail?.querySelector('[data-lg-tabs-scroll="prev"]');
-        const nextBtn = rail?.querySelector('[data-lg-tabs-scroll="next"]');
-        if (!scrollEl || !prevBtn || !nextBtn) return;
-        if (scrollEl.scrollWidth <= scrollEl.clientWidth) {
-            prevBtn.disabled = true;
-            nextBtn.disabled = true;
-            return;
-        }
-        const atStart = scrollEl.scrollLeft <= 0;
-        const atEnd = scrollEl.scrollLeft >= scrollEl.scrollWidth - scrollEl.clientWidth - 1;
-        prevBtn.disabled = atStart;
-        nextBtn.disabled = atEnd;
-    }
-
-    function initTabsRail(rail) {
-        if (!rail || rail.dataset.lgTabsRailInit === "1") return;
-        const scrollEl = rail.querySelector(TABS_SCROLL_SELECTOR);
-        const prevBtn = rail.querySelector('[data-lg-tabs-scroll="prev"]');
-        const nextBtn = rail.querySelector('[data-lg-tabs-scroll="next"]');
-        if (!scrollEl || !prevBtn || !nextBtn) return;
-        rail.dataset.lgTabsRailInit = "1";
-
-        const refresh = () => updateTabsNavState();
-        scrollEl.addEventListener("scroll", refresh, { passive: true });
-        const ro = new ResizeObserver(refresh);
-        ro.observe(scrollEl);
-        ro.observe(rail);
-        refresh();
-    }
-
-    function createTabsRail() {
-        const rail = document.createElement("div");
-        rail.className = TABS_RAIL_CLASS;
-        rail.innerHTML =
-            `<button type="button" class="lg-media-engine-nav lg-media-engine-nav--prev" data-lg-tabs-scroll="prev" aria-label="Scroll tabs left">` +
-            NAV_ICON_PREV +
-            `</button>` +
-            `<div class="lg-results-tabs__scroll"></div>` +
-            `<button type="button" class="lg-media-engine-nav lg-media-engine-nav--next" data-lg-tabs-scroll="next" aria-label="Scroll tabs right">` +
-            NAV_ICON_NEXT +
-            `</button>`;
-        return rail;
-    }
+    const TABS_GROUP_CLASS = "theme-results-tabs-group";
 
     function collectTabNodes(tabs) {
         return [...tabs.children].filter(
@@ -2600,149 +2542,71 @@ function wrapResultsStats(meta) {
         );
     }
 
-    function syncTabsRail() {
+    function syncTabsGroup() {
         const tabs = getResultsTabs();
         if (!tabs) return;
 
-        // The rail is always mounted: it groups the tab buttons so the desktop
-        // grid can place it in column 1, and on mobile it owns the horizontal
-        // scroll + edge-aware arrows. The Filters control (#tools-bar) is a
-        // sibling of the rail on desktop (grid column 2, right-aligned) and
-        // the last item in the scroll list on mobile.
-        let rail = tabs.querySelector(`.${TABS_RAIL_CLASS}`);
-        if (!rail) {
-            rail = createTabsRail();
-            tabs.insertBefore(rail, tabs.firstChild);
+        let group = tabs.querySelector(`:scope > .${TABS_GROUP_CLASS}`);
+        if (!group) {
+            group = document.createElement("div");
+            group.className = TABS_GROUP_CLASS;
+            tabs.appendChild(group);
         }
 
-        const scrollEl = rail.querySelector(TABS_SCROLL_SELECTOR);
-        if (!scrollEl) return;
-
-        // Only move nodes that are not already in the right parent. Moving a
-        // node to the same parent still fires a childList mutation, which the
-        // observer below re-enters as another syncTabsRail() call — an infinite
-        // loop. Guard every appendChild with a parent check.
+        // Core inserts dynamically discovered tabs next to #tools-bar. Keep
+        // those tabs in the capsule without changing the dropdown's placement.
         for (const tab of collectTabNodes(tabs)) {
-            if (tab.parentElement !== scrollEl) scrollEl.appendChild(tab);
+            if (tab.parentElement !== group) group.appendChild(tab);
         }
 
-        const toolsBar = tabs.querySelector("#tools-bar");
-        const wantMobile = mobileQuery.matches;
-        if (toolsBar) {
-            const wantParent = wantMobile ? scrollEl : tabs;
-            if (toolsBar.parentElement !== wantParent) {
-                wantParent.appendChild(toolsBar);
-            }
+        const toolsBar = tabs.querySelector(":scope > #tools-bar");
+        if (toolsBar && toolsBar.nextElementSibling !== group) {
+            tabs.insertBefore(toolsBar, group);
         }
-
-        initTabsRail(rail);
-        updateTabsNavState();
-    }
-
-    function onTabsRailClick(event) {
-        const scrollNav = event.target?.closest?.("[data-lg-tabs-scroll]");
-        if (!scrollNav || scrollNav.disabled) return;
-        const rail = scrollNav.closest(`.${TABS_RAIL_CLASS}`);
-        const scrollEl = rail?.querySelector(TABS_SCROLL_SELECTOR);
-        if (!rail || !scrollEl) return;
-        event.preventDefault();
-        event.stopPropagation();
-
-        const dir = scrollNav.getAttribute("data-lg-tabs-scroll");
-        const containerWidth = scrollEl.clientWidth;
-        const currentScroll = scrollEl.scrollLeft;
-        const maxScroll = scrollEl.scrollWidth - containerWidth;
-        const containerRect = scrollEl.getBoundingClientRect();
-
-        const children = [...scrollEl.children].filter(
-            child => child instanceof HTMLElement && !child.hasAttribute("hidden")
-        );
-        if (!children.length) return;
-
-        let targetScroll = currentScroll;
-
-        if (dir === "next") {
-            const rightBoundary = currentScroll + containerWidth;
-            let targetChild = null;
-            for (const child of children) {
-                const childRect = child.getBoundingClientRect();
-                const childLeft = childRect.left - containerRect.left + currentScroll;
-                if (childLeft >= rightBoundary - 20) {
-                    targetChild = child;
-                    break;
-                }
-            }
-            if (targetChild) {
-                const targetChildRect = targetChild.getBoundingClientRect();
-                targetScroll = targetChildRect.left - containerRect.left + currentScroll;
-            } else {
-                targetScroll = maxScroll;
-            }
-            if (targetScroll - currentScroll < 80) {
-                targetScroll = Math.min(maxScroll, currentScroll + 120);
-            }
-        } else {
-            const leftBoundary = currentScroll;
-            let targetChild = null;
-            for (let i = children.length - 1; i >= 0; i--) {
-                const child = children[i];
-                const childRect = child.getBoundingClientRect();
-                const childRight = childRect.right - containerRect.left + currentScroll;
-                if (childRight <= leftBoundary + 20) {
-                    targetChild = child;
-                    break;
-                }
-            }
-            if (targetChild) {
-                const targetChildRect = targetChild.getBoundingClientRect();
-                const childLeft = targetChildRect.left - containerRect.left + currentScroll;
-                const childWidth = targetChildRect.width;
-                targetScroll = childLeft + childWidth - containerWidth;
-            } else {
-                targetScroll = 0;
-            }
-            if (currentScroll - targetScroll < 80) {
-                targetScroll = Math.max(0, currentScroll - 120);
-            }
-        }
-
-        targetScroll = Math.max(0, Math.min(maxScroll, targetScroll));
-        scrollEl.scrollTo({ left: targetScroll, behavior: "smooth" });
     }
 
     function init() {
         const tabs = getResultsTabs();
         if (!tabs) return;
 
-        if (!tabs.dataset.lgTabsInsertBeforeOverridden) {
-            tabs.dataset.lgTabsInsertBeforeOverridden = "1";
-            const originalInsertBefore = tabs.insertBefore;
-            tabs.insertBefore = function (newNode, referenceNode) {
-                if (referenceNode && referenceNode.id === "tools-bar" && referenceNode.parentElement !== this) {
-                    return referenceNode.parentElement.insertBefore(newNode, referenceNode);
-                }
-                return originalInsertBefore.call(this, newNode, referenceNode);
-            };
-        }
-
-        syncTabsRail();
-        if (!tabs.dataset.lgTabsRailClickWired) {
-            tabs.dataset.lgTabsRailClickWired = "1";
-            tabs.addEventListener("click", onTabsRailClick);
-        }
-        if (!tabs.dataset.lgTabsRailObserver) {
-            tabs.dataset.lgTabsRailObserver = "1";
-            new MutationObserver(() => syncTabsRail()).observe(tabs, {
-                childList: true,
-            });
+        syncTabsGroup();
+        if (!tabs.dataset.laTabsGroupObserver) {
+            tabs.dataset.laTabsGroupObserver = "1";
+            new MutationObserver(syncTabsGroup).observe(tabs, { childList: true });
         }
     }
 
-    onReady(() => {
-        init();
-        mobileQuery.addEventListener?.("change", syncTabsRail);
-        window.addEventListener("resize", () => updateTabsNavState(), { passive: true });
-    });
+    onReady(init);
+    window.addEventListener("degoog-results-ready", init);
+})();
+
+/* ── 4c. Normalize the core's expandable result control ────────────────── */
+(() => {
+    const READ_MORE_CLASS = "theme-read-more-control";
+
+    function markReadMoreControls(root = getResultsPage()) {
+        const scope = root instanceof Element ? root : getResultsPage();
+        if (!scope) return;
+        scope.querySelectorAll("#at-a-glance, #results-list").forEach(container => {
+            container.querySelectorAll("button, [role=button], a, summary").forEach(control => {
+                const label = (control.textContent || "").trim().replace(/\s+/g, " ");
+                if (/^read more\b/i.test(label)) control.classList.add(READ_MORE_CLASS);
+            });
+        });
+    }
+
+    function init() {
+        const page = getResultsPage();
+        markReadMoreControls(page);
+        if (!page || page.dataset.themeReadMoreObserver === "1") return;
+        page.dataset.themeReadMoreObserver = "1";
+        new MutationObserver(() => markReadMoreControls(page)).observe(page, {
+            childList: true,
+            subtree: true,
+        });
+    }
+
+    onReady(init);
     window.addEventListener("degoog-results-ready", init);
 })();
 

--- a/themes/literallyapple/style.css
+++ b/themes/literallyapple/style.css
@@ -3320,6 +3320,7 @@ button.mp2-item[hidden] {
         transform: none !important;
     }
 }
+
 .mp2-toast {
     position: fixed;
     bottom: 2rem;
@@ -4027,4 +4028,333 @@ button.mp2-item[hidden] {
         transition-duration: 0.001ms !important;
         scroll-behavior: auto !important;
     }
+}
+
+/* ── SERP detail polish ────────────────────────────────────────────────── */
+/* Keep search types together in a wrapping capsule; Filters remains its own
+   dropdown pill, placed before the group in the visual order. */
+#results-page #results-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 0.5rem;
+    border: 0;
+    margin-top: 0.75rem;
+    padding: 0;
+}
+
+#results-page #results-tabs .theme-results-tabs-group {
+    display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+    max-width: 100%;
+    padding: 0.25rem;
+    background: var(--la-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-pill);
+}
+
+#results-page #results-tabs > #tools-bar {
+    display: block;
+    flex: 0 0 auto;
+    order: 1;
+}
+
+#results-page #results-tabs > #tools-bar .tools-toggle {
+    min-height: 2.5rem;
+    padding: 0.5rem 0.875rem;
+    background: var(--la-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-pill);
+    color: var(--text-primary);
+    box-shadow: none;
+}
+
+#results-page #results-tabs > #tools-bar .tools-toggle:hover,
+#results-page #results-tabs > #tools-bar .tools-toggle.is-open {
+    background: var(--la-card-hover);
+}
+
+#results-page #results-tabs .results-tab {
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 0.5rem 0.875rem;
+    border: 0;
+    border-radius: var(--theme-radius-pill);
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+#results-page #results-tabs .results-tab:hover {
+    background: var(--la-fill-tertiary);
+    color: var(--text-primary);
+}
+
+#results-page #results-tabs .results-tab.active,
+#results-page #results-tabs .results-tab[aria-selected="true"] {
+    background: var(--la-fill-secondary);
+    border-bottom-color: transparent;
+    color: var(--text-primary);
+}
+
+/* The core's expandable result control has used these class names across
+   versions. Treat it as a compact capsule rather than a full-width strip. */
+#results-page :is(
+    .read-more,
+    .read-more-btn,
+    .read-more-button,
+    .result-read-more,
+    .result-expand,
+    .result-expand-btn,
+    .snippet-expand
+) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    min-height: 2.25rem;
+    padding: 0.4rem 0.875rem;
+    background: var(--la-fill-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-pill);
+    color: var(--text-secondary);
+}
+
+#results-page :is(
+    .read-more,
+    .read-more-btn,
+    .read-more-button,
+    .result-read-more,
+    .result-expand,
+    .result-expand-btn,
+    .snippet-expand
+):hover {
+    background: var(--la-fill-tertiary);
+    color: var(--text-primary);
+}
+
+/* The accordion body already owns the shared outline; a second top border
+   creates the short exposed seams visible beside an open related-searches row. */
+#results-page
+    #results-sidebar
+    .sidebar-accordion:has(.related-search-link).open
+    > .sidebar-accordion-body {
+    border-top: 0;
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+}
+
+@media (min-width: 768px) {
+    #results-page #results-tabs {
+        padding-inline-start: var(--literallyapple-results-content-inline-start) !important;
+        padding-inline-end: 1.25rem !important;
+    }
+}
+
+#results-page #results-tabs {
+    align-items: stretch;
+}
+
+#results-page #results-tabs > #tools-bar {
+    align-self: stretch;
+    display: flex;
+    border-inline-start: 0 !important;
+}
+
+#results-page #results-tabs > #tools-bar::before,
+#results-page #results-tabs > #tools-bar::after {
+    content: none !important;
+    display: none !important;
+}
+
+#results-page #results-tabs > #tools-bar .tools-toggle {
+    flex: 1 1 auto;
+    min-height: 0;
+    text-align: center;
+    justify-content: center;
+}
+
+#results-page #tools-panel .tools-field-toggle {
+    border-radius: var(--theme-radius-pill);
+}
+
+#results-page #results-sidebar .sidebar-accordion > .sidebar-accordion-toggle {
+    border-radius: var(--theme-radius-pill);
+}
+
+#results-page
+    #results-sidebar
+    .sidebar-accordion.open
+    > .sidebar-accordion-toggle {
+    border-end-start-radius: var(--theme-radius-pill);
+    border-end-end-radius: var(--theme-radius-pill);
+}
+
+#results-page #results-sidebar .sidebar-accordion.open > .sidebar-accordion-body {
+    margin-top: 0.5rem;
+    border-top: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-xl);
+}
+
+/* Image-result engine controls wrap as independent pills instead of using a
+   scroll rail with arrow buttons. */
+#results-page .lg-media-engine-rail {
+    display: block;
+    width: 100%;
+}
+
+#results-page .lg-media-engine-nav {
+    display: none !important;
+}
+
+#results-page .lg-media-engine-pills__scroll {
+    overflow: visible !important;
+}
+
+#results-page .lg-media-engine-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+#results-page .lg-media-engine-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.75rem;
+    background: var(--la-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-pill);
+    color: var(--text-secondary);
+}
+
+#results-page .lg-media-engine-pill:hover,
+#results-page .lg-media-engine-pill.is-active {
+    background: var(--la-fill-secondary);
+    color: var(--text-primary);
+}
+
+/* Sidebar accordions own their surface at the toggle/body level so collapsed
+   controls are true pills and expanded controls remain one connected card. */
+#results-page #results-sidebar .sidebar-accordion {
+    background: transparent !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    overflow: visible !important;
+}
+
+#results-page #results-sidebar .sidebar-accordion > .sidebar-accordion-toggle {
+    border-radius: var(--theme-radius-pill) !important;
+}
+
+#results-page
+    #results-sidebar
+    .sidebar-accordion.open
+    > .sidebar-accordion-toggle {
+    border-start-start-radius: var(--theme-radius-xl) !important;
+    border-start-end-radius: var(--theme-radius-xl) !important;
+    border-end-start-radius: 0 !important;
+    border-end-end-radius: 0 !important;
+}
+
+#results-page #results-sidebar .sidebar-accordion.open > .sidebar-accordion-body {
+    margin-top: 0 !important;
+    border-top: 0 !important;
+    border-start-start-radius: 0 !important;
+    border-start-end-radius: 0 !important;
+}
+
+/* The template's decorative Filter icon takes up layout space even when its
+   glyph is not visible. Remove it so the label is optically centered. */
+#results-page #results-tabs > #tools-bar .tools-toggle {
+    display: flex;
+    align-items: center;
+}
+
+#results-page
+    #results-tabs
+    > #tools-bar
+    .tools-toggle
+    > :not(.tools-toggle-label, .lg-filters-label) {
+    display: none;
+}
+
+#results-page
+    #results-tabs
+    > #tools-bar
+    :is(.tools-toggle-label, .lg-filters-label) {
+    flex: 1 1 auto;
+    width: 100%;
+    text-align: center;
+}
+
+#results-page #results-list summary.theme-read-more-control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: auto !important;
+    inline-size: fit-content !important;
+    min-height: 2.25rem;
+    margin-inline: auto;
+    padding: 0.4rem 0.875rem;
+    list-style: none;
+    background: var(--la-fill-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--theme-radius-pill);
+    color: var(--text-secondary);
+}
+
+#results-page #results-list summary.theme-read-more-control::-webkit-details-marker {
+    display: none;
+}
+
+#results-page .theme-read-more-control {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: fit-content !important;
+    inline-size: fit-content !important;
+    min-width: 0 !important;
+    min-height: 2.25rem !important;
+    margin-inline: auto !important;
+    padding: 0.4rem 0.875rem !important;
+    background: var(--la-fill-secondary) !important;
+    border: 1px solid var(--border-light) !important;
+    border-radius: var(--theme-radius-pill) !important;
+    color: var(--text-secondary) !important;
+}
+
+#results-page .theme-read-more-control:hover {
+    background: var(--la-fill-tertiary) !important;
+    color: var(--text-primary) !important;
+}
+
+/* The AI Summary extension hides this control after expanding. Preserve that
+   state even though the theme's visible pill declaration uses !important. */
+#results-page .theme-read-more-control[hidden] {
+    display: none !important;
+}
+
+#results-page #at-a-glance .glance-ai-input.degoog-input--chat {
+    border-radius: var(--theme-radius-pill) !important;
+}
+
+#results-page :is(
+    .theme-read-more-control,
+    .read-more,
+    .read-more-btn,
+    .read-more-button,
+    .result-read-more,
+    .result-expand,
+    .result-expand-btn,
+    .snippet-expand
+) {
+    align-self: center;
+    width: auto !important;
+    inline-size: fit-content !important;
+    margin-inline: auto;
 }


### PR DESCRIPTION
## Summary

- Refine LiterallyApple results-tab grouping and read-more controls.
- Add layout and styling polish for the LiterallyApple theme.
- Keep this PR scoped to the theme files only; the shopping engine and Shopping tab are not included.

## Testing

- Not run (theme-only changes).